### PR TITLE
fix: actions channel should be empty on new press

### DIFF
--- a/src/hook.rs
+++ b/src/hook.rs
@@ -19,7 +19,7 @@ use windows::Win32::UI::WindowsAndMessaging::{
 };
 
 /// Timeout for blocking key events, measured in milliseconds.
-const TIMEOUT: Duration = Duration::from_millis(100);
+const TIMEOUT: Duration = Duration::from_millis(250);
 
 /// Unassigned Virtual Key code used to suppress Windows Key events.
 const SILENT_KEY: VIRTUAL_KEY = VIRTUAL_KEY(0xE8);
@@ -207,6 +207,8 @@ unsafe extern "system" fn hook_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -
         match event_type {
             // We only care about key down events
             WM_KEYDOWN | WM_SYSKEYDOWN => {
+                // Clear the actions channel of any previous action
+                while let Ok(_) = response_rx.try_recv() {}
                 update_keyboard_state(vk_code);
                 event_tx
                     .send(KeyboardEvent::KeyDown {


### PR DESCRIPTION
- Make sure the actions channel is always empty when handling a new keydown event.
- Raise the timeout to prevent keys from being ignored when the system is busy.
- Update the keyboard state on `WM_KEYUP` events as well to better keep track of the overall keyboard state. _(@iholston I think this doesn't hurt having to make sure the keyboard state is always in sync, but if you don't want it I can remove it, from my tests it seemed that the keyboard state would only update on the next keydown event so if we can update it on the keyup is probably better...)_

Fixes #7 